### PR TITLE
Use theme config image for empty cart page

### DIFF
--- a/frontend/components/EmptyCart/index.jsx
+++ b/frontend/components/EmptyCart/index.jsx
@@ -1,21 +1,33 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import I18n from '@shopgate/pwa-common/components/I18n';
+import { themeConfig } from '@shopgate/pwa-common/helpers/config';
+import { encodeSVG } from '@shopgate/engage/core';
 import Icon from './components/Icon';
 import styles from './style';
 
+const { fullSVGs } = themeConfig;
+
 /**
  * The Cart Empty component.
+ * If configured, theme config will override the icon here
  * @return {JSX.Element}
  */
-const Empty = () => (
-  <div className={styles.container}>
-    <div className={styles.icon}>
-      <Icon />
+const Empty = () => {
+  const { emptyCart } = fullSVGs;
+
+  const imageSRC = useMemo(() => encodeSVG(emptyCart),
+    [emptyCart]);
+
+  return (
+    <div className={styles.container}>
+      <div className={imageSRC ? styles.image : styles.icon} aria-hidden>
+        {imageSRC ? <img src={imageSRC} alt="" /> : <Icon />}
+      </div>
+      <div className={styles.title}>
+        <I18n.Text string="cart.empty" />
+      </div>
     </div>
-    <div className={styles.title}>
-      <I18n.Text string="cart.empty" />
-    </div>
-  </div>
-);
+  );
+};
 
 export default Empty;

--- a/frontend/components/EmptyCart/style.js
+++ b/frontend/components/EmptyCart/style.js
@@ -1,7 +1,7 @@
 import { css } from 'glamor';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 
-const { colors } = themeConfig;
+const { colors, variables } = themeConfig;
 
 const container = css({
   display: 'flex',
@@ -18,6 +18,10 @@ const icon = css({
   padding: '1em 0 0',
 }).toString();
 
+const image = css({
+  width: variables.emptyPage.icon,
+}).toString();
+
 const title = css({
   textAlign: 'left',
   color: colors.shade6,
@@ -27,4 +31,5 @@ export default {
   container,
   icon,
   title,
+  image,
 };

--- a/frontend/components/NoProducts/index.jsx
+++ b/frontend/components/NoProducts/index.jsx
@@ -1,15 +1,27 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import I18n from '@shopgate/pwa-common/components/I18n';
+import { themeConfig } from '@shopgate/pwa-common/helpers/config';
+import { encodeSVG } from '@shopgate/engage/core';
 import styles from './style';
+
+const { fullSVGs } = themeConfig;
 
 /**
  * No products component
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
-const NoProducts = () => (
-  <div className={styles.wrapper}>
-    <I18n.Text string="recently_viewed_products.empty_product_list" />
-  </div>
-);
+const NoProducts = () => {
+  const { noResultsImage } = fullSVGs;
+
+  const imageSRC = useMemo(() => encodeSVG(noResultsImage),
+    [noResultsImage]);
+
+  return (
+    <div className={styles.wrapper}>
+      {noResultsImage && <img src={imageSRC} alt="" />}
+      <I18n.Text string="recently_viewed_products.empty_product_list" />
+    </div>
+  );
+};
 
 export default NoProducts;


### PR DESCRIPTION
It is possible to configure an image for the "empty cart page" in the theme config as well as the "no products page". If this is the case, that image should not be overwritten by this extension so we adjusted this.
